### PR TITLE
Add optional parameter existing_entries to extract()

### DIFF
--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -104,7 +104,7 @@ class N26Importer(importer.ImporterProtocol):
 
         return self.is_valid_header(line)
 
-    def extract(self, file_):
+    def extract(self, file_, existing_entries=None):
         entries = []
 
         if not self.identify(file_):


### PR DESCRIPTION
beancount/ingest/importer.py defines extract() as:

    def extract(self, file, existing_entries=None):
...
          existing_entries: An optional list of existing directives loaded from
            the ledger which is intended to contain the extracted entries. This
            is only provided if the user provides them via a flag in the
            extractor program.

smart_importer's hooks pass existing_entries to extract() and the N26
importer fails because it doesn't recognize this optional argument.