### PR TITLE
importer: Add support for currency conversions

### DIFF
--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -128,7 +128,7 @@ class N26Importer(importer.ImporterProtocol):
         self,
         iban: str,
         account: str,
-        exchange_fees_account: str,
+        exchange_fees_account: str = None,
         language: str = 'en',
         file_encoding: str = 'utf-8',
         account_patterns: Dict[str, List[str]] = {},
@@ -256,6 +256,10 @@ class N26Importer(importer.ImporterProtocol):
                     fees = amount_eur + abs(amount_foreign / exchange_rate)
 
                     if fees != 0:
+                        assert (
+                            self.exchange_fees_account
+                        ), "exchange_fees_account required for conversion fees"
+
                         postings += [
                             data.Posting(
                                 self.account,

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -128,7 +128,7 @@ class N26Importer(importer.ImporterProtocol):
         self,
         iban: str,
         account: str,
-        transferwise_fees_account: str,
+        exchange_fees_account: str,
         language: str = 'en',
         file_encoding: str = 'utf-8',
         account_patterns: Dict[str, List[str]] = {},
@@ -138,7 +138,7 @@ class N26Importer(importer.ImporterProtocol):
         self.language = language
         self.file_encoding = file_encoding
         self.payee_patterns = set()
-        self.transferwise_fees_account = transferwise_fees_account
+        self.exchange_fees_account = exchange_fees_account
 
         if not _is_language_supported(language):
             raise InvalidFormatError(
@@ -265,7 +265,7 @@ class N26Importer(importer.ImporterProtocol):
                             None,
                         ),
                         data.Posting(
-                            self.transferwise_fees_account,
+                            self.exchange_fees_account,
                             Amount(fees, 'EUR'),
                             None,
                             None,

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -276,7 +276,7 @@ class N26Importer(importer.ImporterProtocol):
                             self.account,
                             Amount(amount_eur - fees, 'EUR'),
                             CostSpec(
-                                exchange_rate, None, 'CHF', None, None, None
+                                exchange_rate, None, currency, None, None, None
                             ),
                             None,
                             None,

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -230,6 +230,13 @@ class N26Importer(importer.ImporterProtocol):
         if not self.identify(file_):
             return []
 
+        s_amount_eur = self._translate('amount_eur')
+        s_amount_foreign_currency = self._translate('amount_foreign_currency')
+        s_payee = self._translate('payee')
+        s_payment_reference = self._translate('payment_reference')
+        s_type_foreign_currency = self._translate('type_foreign_currency')
+        s_exchange_rate = self._translate('exchange_rate')
+
         with open(file_.name, encoding=self.file_encoding) as fd:
             reader = csv.DictReader(
                 fd, delimiter=',', quoting=csv.QUOTE_MINIMAL, quotechar='"'
@@ -237,17 +244,6 @@ class N26Importer(importer.ImporterProtocol):
 
             for index, line in enumerate(reader):
                 meta = data.new_metadata(file_.name, index)
-
-                s_amount_eur = self._translate('amount_eur')
-                s_amount_foreign_currency = self._translate(
-                    'amount_foreign_currency'
-                )
-                s_payee = self._translate('payee')
-                s_payment_reference = self._translate('payment_reference')
-                s_type_foreign_currency = self._translate(
-                    'type_foreign_currency'
-                )
-                s_exchange_rate = self._translate('exchange_rate')
 
                 postings = []
 

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -253,7 +253,7 @@ class N26Importer(importer.ImporterProtocol):
                     amount_foreign = Decimal(line[s_amount_foreign_currency])
                     currency = line[s_type_foreign_currency]
 
-                    fees = amount_eur + (amount_foreign / exchange_rate)
+                    fees = amount_eur + abs(amount_foreign / exchange_rate)
 
                     postings += [
                         data.Posting(

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -255,23 +255,27 @@ class N26Importer(importer.ImporterProtocol):
 
                     fees = amount_eur + abs(amount_foreign / exchange_rate)
 
+                    if fees != 0:
+                        postings += [
+                            data.Posting(
+                                self.account,
+                                Amount(-fees, 'EUR'),
+                                None,
+                                None,
+                                None,
+                                None,
+                            ),
+                            data.Posting(
+                                self.exchange_fees_account,
+                                Amount(fees, 'EUR'),
+                                None,
+                                None,
+                                None,
+                                None,
+                            ),
+                        ]
+
                     postings += [
-                        data.Posting(
-                            self.account,
-                            Amount(-fees, 'EUR'),
-                            None,
-                            None,
-                            None,
-                            None,
-                        ),
-                        data.Posting(
-                            self.exchange_fees_account,
-                            Amount(fees, 'EUR'),
-                            None,
-                            None,
-                            None,
-                            None,
-                        ),
                         data.Posting(
                             self.account,
                             Amount(amount_eur - fees, 'EUR'),

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -355,7 +355,11 @@ def test_extract_conversion(importer, filename):
         postings=[
             ('Assets:N26', 'EUR', Decimal('0')),
             ('Expenses:TransferWise', 'EUR', Decimal('-0')),
-            ('Assets:N26', 'EUR', Decimal('-12.21') / Decimal('1'), ('EUR', Decimal('1'))),
+            (
+                'Assets:N26',
+                'EUR',
+                Decimal('-12.21') / Decimal('1'),
+                ('EUR', Decimal('1')),
+            ),
         ],
     )
-

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -293,6 +293,7 @@ def test_extract_conversion(importer, filename):
                 "2022-08-01","Alice","{iban_number}","Income","Muster GmbH","Income","56.78","","",""
                 "2022-08-02","Bob","{iban_number}","Outgoing Transfer","Home food","Foo","-42.0","","",""
                 "2022-08-03","Charlie","{iban_number}","Outgoing Transfer in a foreign currency","Foreign food","Bar","-10.0","9.13","CHF","0.9687"
+                "2022-08-04","Mustermann GmbH","{iban_number}","-","MasterCard Payment","-","-12.21","-12.21","EUR","1.0"
                 ''',  # NOQA
                 language=importer.language,
             )
@@ -302,8 +303,8 @@ def test_extract_conversion(importer, filename):
         transactions = importer.extract(fd)
         date = importer.file_date(fd)
 
-    assert date == datetime.date(2022, 8, 3)
-    assert len(transactions) == 3
+    assert date == datetime.date(2022, 8, 4)
+    assert len(transactions) == 4
 
     assert_transaction(
         transaction=transactions[0],
@@ -345,3 +346,16 @@ def test_extract_conversion(importer, filename):
             ),
         ],
     )
+
+    assert_transaction(
+        transaction=transactions[3],
+        date=datetime.date(2022, 8, 4),
+        payee='Mustermann GmbH',
+        narration='MasterCard Payment',
+        postings=[
+            ('Assets:N26', 'EUR', Decimal('0')),
+            ('Expenses:TransferWise', 'EUR', Decimal('-0')),
+            ('Assets:N26', 'EUR', Decimal('-12.21') / Decimal('1'), ('EUR', Decimal('1'))),
+        ],
+    )
+

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -353,8 +353,6 @@ def test_extract_conversion(importer, filename):
         payee='Mustermann GmbH',
         narration='MasterCard Payment',
         postings=[
-            ('Assets:N26', 'EUR', Decimal('0')),
-            ('Expenses:TransferWise', 'EUR', Decimal('-0')),
             (
                 'Assets:N26',
                 'EUR',

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -36,7 +36,9 @@ def filename(tmp_path):
 
 @pytest.fixture
 def importer(language):
-    return N26Importer(IBAN_NUMBER, 'Assets:N26', language)
+    return N26Importer(
+        IBAN_NUMBER, 'Assets:N26', 'Expenses:TransferWise', language
+    )
 
 
 @pytest.fixture
@@ -123,6 +125,9 @@ def assert_transaction(
         else:
             assert actual.units.currency == expected[1]
             assert actual.units.number == expected[2]
+            if len(expected) > 3:
+                assert actual.cost.currency == expected[3][0]
+                assert actual.cost.number_per == expected[3][1]
 
 
 def test_extract_single_transaction(importer, filename):
@@ -277,3 +282,66 @@ def test_raise_on_payee_in_multiple_accounts(language):
                 ],
             },
         )
+
+
+def test_extract_conversion(importer, filename):
+    with open(filename, 'wb') as fd:
+        fd.write(
+            _format(
+                '''
+                {header}
+                "2022-08-01","Alice","{iban_number}","Income","Muster GmbH","Income","56.78","","",""
+                "2022-08-02","Bob","{iban_number}","Outgoing Transfer","Home food","Foo","-42.0","","",""
+                "2022-08-03","Charlie","{iban_number}","Outgoing Transfer in a foreign currency","Foreign food","Bar","-10.0","9.13","CHF","0.9687"
+                ''',  # NOQA
+                language=importer.language,
+            )
+        )
+
+    with open(filename) as fd:
+        transactions = importer.extract(fd)
+        date = importer.file_date(fd)
+
+    assert date == datetime.date(2022, 8, 3)
+    assert len(transactions) == 3
+
+    assert_transaction(
+        transaction=transactions[0],
+        date=datetime.date(2022, 8, 1),
+        payee='Alice',
+        narration='Muster GmbH',
+        postings=[
+            ('Assets:N26', 'EUR', Decimal('56.78')),
+        ],
+    )
+
+    assert_transaction(
+        transaction=transactions[1],
+        date=datetime.date(2022, 8, 2),
+        payee='Bob',
+        narration='Home food',
+        postings=[
+            ('Assets:N26', 'EUR', Decimal('-42.0')),
+        ],
+    )
+
+    assert_transaction(
+        transaction=transactions[2],
+        date=datetime.date(2022, 8, 3),
+        payee='Charlie',
+        narration='Foreign food',
+        postings=[
+            ('Assets:N26', 'EUR', Decimal('0.574997419221637245793331269')),
+            (
+                'Expenses:TransferWise',
+                'EUR',
+                Decimal('-0.574997419221637245793331269'),
+            ),
+            (
+                'Assets:N26',
+                'EUR',
+                Decimal('-9.13') / Decimal('0.9687'),
+                ('CHF', Decimal('0.9687')),
+            ),
+        ],
+    )


### PR DESCRIPTION
This patch adds support for outgoing transactions using TransferWise (EUR -> XXX). I don't have examples of transactions of (XXX -> EUR) or of CC payments using another currency (EUR -> XXX), so I didn't include support for that.

This patch will produce a Transaction with 3 (or 4) Postings, this is to correctly include fees when we don't have the 4th transaction :

```csv
"2022-08-03","Charlie","{iban_number}","Outgoing Transfer in a foreign currency","Foreign food","Bar","-10.0","9.13","CHF","0.9687"
```

will produce

```beancount
2022-08-03 * "Charlie" "Foreign food"
  Assets:N26              0.574997419221637245793331269 EUR
  Expenses:TransferWise  -0.574997419221637245793331269 EUR
  Assets:N26             -9.425002580778362754206668731 EUR {0.9687 CHF}
```

Note: I'm not sure `Outgoing Transfer in a foreign currency` is the exact content of the `amount_foreign_currency` column in english. It's a translation of the french one: `Virement dans une devise étrangère`.