### PR TITLE
fix: proper support of multi-currency postings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,51 +106,6 @@ CONFIG = [
 ]
 ```
 
-### Multiple-currency transactions
-
-To mark transaction fees associated with multiple-currency transactions, you can
-specify the `exchange_fees_account` parameter.
-
-#### Beancount 3.x
-
-```python
-from beancount_n26 import N26Importer
-from beangulp import Ingest
-
-importers = (
-    N26Importer(
-        IBAN_NUMBER,
-        'Assets:N26',
-        exchange_fees_account="Expenses:TransferWise"
-    ),
-)
-
-if __name__ == "__main__":
-    ingest = Ingest(importer)
-    ingest()
-```
-
-#### Beancount 2.x
-
-```python
-from beancount_n26 import N26Importer
-
-CONFIG = [
-    N26Importer(
-        IBAN_NUMBER,
-        'Assets:N26',
-        language='en',
-        file_encoding='utf-8',
-        exchange_fees_account='Expenses:TransferWise',
-    ),
-]
-```
-
-With this in place, for transactions where both the amount in EUR and amount in foreign
-currency are given, the importer will calculate the transaction fee based on the
-exchange rate included in the CSV export and automatically allocate the value to the
-account specified in `exchange_fees_account`.
-
 ## Contributing
 
 Please make sure you have Python 3.9+ and [Poetry] installed.

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional
 from beancount.core import data, flags
 from beancount.core.amount import Amount
 from beancount.core.number import Decimal
-from beancount.core.position import CostSpec
 from beangulp.importer import Importer
 
 HeaderField = namedtuple("HeaderField", ["label", "optional"])
@@ -267,42 +266,15 @@ class N26Importer(Importer):
 
                 if line[s_amount_foreign_currency] and line[s_type_foreign_currency] != 'EUR':
                     exchange_rate = Decimal(line[s_exchange_rate])
-                    amount_eur = Decimal(line[s_amount_eur])
                     amount_foreign = Decimal(line[s_amount_foreign_currency])
                     currency = line[s_type_foreign_currency]
-
-                    fees = amount_eur + abs(amount_foreign / exchange_rate)
-
-                    if fees != 0:
-                        assert (
-                            self.exchange_fees_account
-                        ), "exchange_fees_account required for conversion fees"
-
-                        postings += [
-                            data.Posting(
-                                self.account(filepath),
-                                Amount(-fees, "EUR"),
-                                None,
-                                None,
-                                None,
-                                None,
-                            ),
-                            data.Posting(
-                                self.exchange_fees_account,
-                                Amount(fees, "EUR"),
-                                None,
-                                None,
-                                None,
-                                None,
-                            ),
-                        ]
 
                     postings += [
                         data.Posting(
                             self.account(filepath),
-                            Amount(amount_eur - fees, "EUR"),
-                            CostSpec(exchange_rate, None, currency, None, None, None),
+                            Amount(-amount_foreign, currency),
                             None,
+                            Amount(Decimal(1.0) / exchange_rate, "EUR"),
                             None,
                             None,
                         ),

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -265,7 +265,7 @@ class N26Importer(Importer):
 
                 postings = []
 
-                if line[s_amount_foreign_currency]:
+                if line[s_amount_foreign_currency] and line[s_type_foreign_currency] != 'EUR':
                     exchange_rate = Decimal(line[s_exchange_rate])
                     amount_eur = Decimal(line[s_amount_eur])
                     amount_foreign = Decimal(line[s_amount_foreign_currency])

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -124,14 +124,12 @@ class N26Importer(Importer):
         language: str = "en",
         file_encoding: str = "utf-8",
         account_patterns: Dict[str, List[str]] = {},
-        exchange_fees_account: Optional[str] = None,
     ):
         self.iban = iban
         self.account_name = account_name
         self.language = language
         self.file_encoding = file_encoding
         self.payee_patterns = set()
-        self.exchange_fees_account = exchange_fees_account
 
         self._filepath = None
         self._translation_strings = None

--- a/beancount_n26/__init__.py
+++ b/beancount_n26/__init__.py
@@ -194,9 +194,6 @@ class N26Importer(Importer):
     def _parse_date(self, entry):
         return datetime.strptime(entry[self._translate("date")], "%Y-%m-%d").date()
 
-    def name(self):
-        return "N26 {}".format(self.__class__.__name__)
-
     def date(self, filepath: str) -> Optional[datetime.date]:
         if not self.identify(filepath):
             return None
@@ -253,12 +250,14 @@ class N26Importer(Importer):
         s_exchange_rate = self._translate("exchange_rate")
 
         with open(filepath, encoding=self.file_encoding) as fd:
+            lines = [line.strip() for line in fd.readlines()]
             reader = csv.DictReader(
-                fd, delimiter=",", quoting=csv.QUOTE_MINIMAL, quotechar='"'
+                lines, delimiter=",", quoting=csv.QUOTE_MINIMAL, quotechar='"'
             )
 
             for index, line in enumerate(reader):
                 meta = data.new_metadata(filepath, index)
+                meta["__source__"] = lines[index]
 
                 postings = []
 

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -28,7 +28,6 @@ def importer():
         IBAN_NUMBER,
         "Assets:N26",
         language="en",
-        exchange_fees_account="Expenses:Exchange",
     )
 
 

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -193,9 +193,7 @@ def test_extract_conversion(importer, filename):
         Assets:N26  -42.0 EUR
 
       2022-08-03 * "Charlie" "Foreign food"
-        Assets:N26          0.574997419221637245793331269 EUR
-        Expenses:Exchange  -0.574997419221637245793331269 EUR
-        Assets:N26         -9.425002580778362754206668731 EUR {0.9687 CHF}
+        Assets:N26  -9.13 CHF @ 1.032311345101682667492515743 EUR
 
       2022-08-04 * "Mustermann GmbH" "MasterCard Payment"
         Assets:N26  -12.21 EUR

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -198,7 +198,7 @@ def test_extract_conversion(importer, filename):
         Assets:N26         -9.425002580778362754206668731 EUR {0.9687 CHF}
 
       2022-08-04 * "Mustermann GmbH" "MasterCard Payment"
-        Assets:N26  -12.21 EUR {1.0 EUR}
+        Assets:N26  -12.21 EUR
    """, transactions, allow_incomplete=True)
 
 def test_extract_updated_header(importer, filename):

--- a/tests/test_n26_importer.py
+++ b/tests/test_n26_importer.py
@@ -1,35 +1,26 @@
 import datetime
-import os.path
 from textwrap import dedent
 
-from beancount.core.number import Decimal
-from beancount.core.data import Transaction
+from beancount.parser.cmptest import TestCase as BeancountTest
+from beancount.parser.booking import convert_lot_specs_to_lots
 import pytest
 
-from typing import Optional, List, Tuple
-
-from beancount_n26 import _header_values_for, N26Importer, HEADER_FIELDS
+from beancount_n26 import N26Importer, HEADER_FIELDS
 
 IBAN_NUMBER = "DE99 9999 9999 9999 9999 99".replace(" ", "")
 
 
-def _format(string, **kwargs):
-    headers = _header_values_for(**kwargs)
-
-    kwargs.update(
-        {
-            "iban_number": IBAN_NUMBER,
-            "header": ",".join(headers[0]),
-        }
-    )
-
-    return dedent(string).format(**kwargs).lstrip().encode("utf-8")
-
+def assert_equal_entries(expected_entries, actual_entries, allow_incomplete=False):
+    # convert CostSpec to Cost to allow comparison
+    actual_with_costs = convert_lot_specs_to_lots(actual_entries)[0]
+    BeancountTest.assertEqualEntries(pytest, expected_entries, actual_with_costs, allow_incomplete)
 
 @pytest.fixture
-def filename(tmp_path):
-    return os.path.join(str(tmp_path), "{}.csv".format(IBAN_NUMBER))
-
+def filename(request, tmp_path):
+    with open(tmp_path / 'input.csv', 'w') as file:
+        file.write(dedent(request.function.__doc__))
+        file.flush()
+        return file.name
 
 @pytest.fixture
 def importer():
@@ -42,191 +33,98 @@ def importer():
 
 
 def test_identify_with_optional(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2019-10-10","MAX MUSTERMANN","{iban_number}","Outgoing Transfer","Muster GmbH","Miscellaneous","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2019-10-10","MAX MUSTERMANN","DE99999999999999999999","Outgoing Transfer","Muster GmbH","Miscellaneous","-12.34","","",""
+    """
 
     assert importer.identify(filename)
 
 
 def test_identify_without_optional(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2019-10-10","MAX MUSTERMANN","{iban_number}","Outgoing Transfer","Muster GmbH","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2019-10-10","MAX MUSTERMANN","DE99999999999999999999","Outgoing Transfer","Muster GmbH","-12.34","","",""
+    """
 
     assert importer.identify(filename)
 
 
 def test_identify_german(importer, filename):
+    """\
+    "Datum","Empfänger","Kontonummer","Transaktionstyp","Verwendungszweck","Kategorie","Betrag (EUR)","Betrag (Fremdwährung)","Fremdwährung","Wechselkurs"
+    "2019-10-10","MAX MUSTERMANN","DE99999999999999999999","Outgoing Transfer","Muster GmbH","-12.34","","",""
+    """
     importer.language = "de"
-
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Datum","Empfänger","Kontonummer","Transaktionstyp","Verwendungszweck","Kategorie","Betrag (EUR)","Betrag (Fremdwährung)","Fremdwährung","Wechselkurs"
-                "2019-10-10","MAX MUSTERMANN","{iban_number}","Outgoing Transfer","Muster GmbH","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
 
     assert importer.identify(filename)
 
 
 def test_identify_french(importer, filename):
+    """\
+    "Date","Bénéficiaire","Numéro de compte","Type de transaction","Référence de paiement","Catégorie","Montant (EUR)","Montant (Devise étrangère)","Sélectionnez la devise étrangère","Taux de conversion"
+    "2019-10-10","MAX MUSTERMANN","DE99999999999999999999","Outgoing Transfer","Muster GmbH","-12.34","","",""
+    """
+
     importer.language = "fr"
-
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Bénéficiaire","Numéro de compte","Type de transaction","Référence de paiement","Catégorie","Montant (EUR)","Montant (Devise étrangère)","Sélectionnez la devise étrangère","Taux de conversion"
-                "2019-10-10","MAX MUSTERMANN","{iban_number}","Outgoing Transfer","Muster GmbH","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
-
     assert importer.identify(filename)
 
 
 def test_extract_no_transactions(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                """,
-                language=importer.language,
-            )
-        )
-
+    """
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    """
     transactions = importer.extract(filename)
 
     assert len(transactions) == 0
 
 
-def assert_transaction(
-    transaction: Transaction,
-    date: datetime,
-    payee: str,
-    narration: str,
-    postings: List[Tuple[str, Optional[str], Optional[Decimal]]],
-):
-    assert transaction.date == date
-    assert transaction.payee == payee
-    assert transaction.narration == narration
-
-    assert len(postings) == len(transaction.postings)
-    for expected, actual in zip(postings, transaction.postings):
-        assert actual.account == expected[0]
-        if actual.units is None:
-            assert expected[1] is None
-            assert expected[2] is None
-        else:
-            assert actual.units.currency == expected[1]
-            assert actual.units.number == expected[2]
-            if len(expected) > 3:
-                assert actual.cost.currency == expected[3][0]
-                assert actual.cost.number_per == expected[3][1]
-
-
 def test_extract_single_transaction(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2019-10-10","Muster GmbH","{iban_number}","Outgoing Transfer","Muster payment","Miscellaneous","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2019-10-10","Muster GmbH","DE99999999999999999999","Outgoing Transfer","Muster payment","Miscellaneous","-12.34","","",""
+    """
 
     transactions = importer.extract(filename)
     date = importer.date(filename)
 
     assert date == datetime.date(2019, 10, 10)
-
-    assert len(transactions) == 1
-    assert_transaction(
-        transaction=transactions[0],
-        date=datetime.date(2019, 10, 10),
-        payee="Muster GmbH",
-        narration="Muster payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-12.34")),
-        ],
-    )
-
+    assert_equal_entries(r"""
+      2019-10-10 * "Muster GmbH" "Muster payment"
+        Assets:N26  -12.34 EUR
+    """, transactions)
 
 def test_extract_multiple_transactions(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2019-12-28","MAX MUSTERMANN","{iban_number}","Income","Muster GmbH","Income","-56.78","","",""
-                "2020-01-05","Muster SARL","{iban_number}","Outgoing Transfer","Muster Fr payment","Income","-42.24","","",""
-                "2020-01-03","Muster GmbH","{iban_number}","Outgoing Transfer","Muster De payment","Income","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2019-12-28","MAX MUSTERMANN","DE99999999999999999999","Income","Muster GmbH","Income","-56.78","","",""
+    "2020-01-05","Muster SARL","DE99999999999999999999","Outgoing Transfer","Muster Fr payment","Income","-42.24","","",""
+    "2020-01-03","Muster GmbH","DE99999999999999999999","Outgoing Transfer","Muster De payment","Income","-12.34","","",""
+    """
 
     transactions = importer.extract(filename)
     date = importer.date(filename)
 
     assert date == datetime.date(2020, 1, 5)
-    assert len(transactions) == 3
+    assert_equal_entries(r"""
+      2019-12-28 * "MAX MUSTERMANN" "Muster GmbH"
+          Assets:N26     -56.78 EUR
 
-    assert_transaction(
-        transaction=transactions[0],
-        date=datetime.date(2019, 12, 28),
-        payee="MAX MUSTERMANN",
-        narration="Muster GmbH",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-56.78")),
-        ],
-    )
+      2020-01-03 * "Muster GmbH" "Muster De payment"
+          Assets:N26  -12.34 EUR
 
-    assert_transaction(
-        transaction=transactions[1],
-        date=datetime.date(2020, 1, 5),
-        payee="Muster SARL",
-        narration="Muster Fr payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-42.24")),
-        ],
-    )
-
-    assert_transaction(
-        transaction=transactions[2],
-        date=datetime.date(2020, 1, 3),
-        payee="Muster GmbH",
-        narration="Muster De payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-12.34")),
-        ],
-    )
-
+      2020-01-05 * "Muster SARL" "Muster Fr payment"
+          Assets:N26  -42.24 EUR
+    """, transactions)
 
 def test_extract_multiple_transactions_with_classification(filename):
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2019-12-28","MAX MUSTERMANN","DE99999999999999999999","Income","Muster GmbH","Income","-56.78","","",""
+    "2020-01-05","Muster SARL","DE99999999999999999999","Outgoing Transfer","Muster Fr payment","Income","-42.24","","",""
+    "2020-01-03","Muster GmbH","DE99999999999999999999","Outgoing Transfer","Muster De payment","Income","-12.34","","",""
+    """
+
     importer = N26Importer(
         IBAN_NUMBER,
         "Assets:N26",
@@ -238,55 +136,21 @@ def test_extract_multiple_transactions_with_classification(filename):
         },
     )
 
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2019-12-28","MAX MUSTERMANN","{iban_number}","Income","Muster GmbH","Income","-56.78","","",""
-                "2020-01-05","Muster SARL","{iban_number}","Outgoing Transfer","Muster Fr payment","Income","-42.24","","",""
-                "2020-01-03","Muster GmbH","{iban_number}","Outgoing Transfer","Muster De payment","Income","-12.34","","",""
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
-
     transactions = importer.extract(filename)
     date = importer.date(filename)
 
     assert date == datetime.date(2020, 1, 5)
-    assert len(transactions) == 3
+    assert_equal_entries(r"""
+      2019-12-28 * "MAX MUSTERMANN" "Muster GmbH"
+          Assets:N26     -56.78 EUR
+          Expenses:Misc
 
-    assert_transaction(
-        transaction=transactions[0],
-        date=datetime.date(2019, 12, 28),
-        payee="MAX MUSTERMANN",
-        narration="Muster GmbH",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-56.78")),
-            ("Expenses:Misc", None, None),
-        ],
-    )
+      2020-01-03 * "Muster GmbH" "Muster De payment"
+          Assets:N26  -12.34 EUR
 
-    assert_transaction(
-        transaction=transactions[1],
-        date=datetime.date(2020, 1, 5),
-        payee="Muster SARL",
-        narration="Muster Fr payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-42.24")),
-        ],
-    )
-
-    assert_transaction(
-        transaction=transactions[2],
-        date=datetime.date(2020, 1, 3),
-        payee="Muster GmbH",
-        narration="Muster De payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-12.34")),
-        ],
-    )
+      2020-01-05 * "Muster SARL" "Muster Fr payment"
+          Assets:N26  -42.24 EUR
+    """, transactions, allow_incomplete=True)
 
 
 @pytest.mark.parametrize("language", HEADER_FIELDS.keys())
@@ -308,107 +172,47 @@ def test_raise_on_payee_in_multiple_accounts(language):
 
 
 def test_extract_conversion(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
-                "2022-08-01","Alice","{iban_number}","Income","Muster GmbH","Income","56.78","","",""
-                "2022-08-02","Bob","{iban_number}","Outgoing Transfer","Home food","Foo","-42.0","","",""
-                "2022-08-03","Charlie","{iban_number}","Outgoing Transfer in a foreign currency","Foreign food","Bar","-10.0","9.13","CHF","0.9687"
-                "2022-08-04","Mustermann GmbH","{iban_number}","-","MasterCard Payment","-","-12.21","-12.21","EUR","1.0"
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Date","Payee","Account number","Transaction type","Payment reference","Category","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency","Exchange Rate"
+    "2022-08-01","Alice","DE99999999999999999999","Income","Muster GmbH","Income","56.78","","",""
+    "2022-08-02","Bob","DE99999999999999999999","Outgoing Transfer","Home food","Foo","-42.0","","",""
+    "2022-08-03","Charlie","DE99999999999999999999","Outgoing Transfer in a foreign currency","Foreign food","Bar","-10.0","9.13","CHF","0.9687"
+    "2022-08-04","Mustermann GmbH","DE99999999999999999999","-","MasterCard Payment","-","-12.21","-12.21","EUR","1.0"
+    """
 
     transactions = importer.extract(filename)
+
     date = importer.date(filename)
-
     assert date == datetime.date(2022, 8, 4)
-    assert len(transactions) == 4
 
-    assert_transaction(
-        transaction=transactions[0],
-        date=datetime.date(2022, 8, 1),
-        payee="Alice",
-        narration="Muster GmbH",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("56.78")),
-        ],
-    )
+    assert_equal_entries(r"""
+      2022-08-01 * "Alice" "Muster GmbH"
+        Assets:N26  56.78 EUR
 
-    assert_transaction(
-        transaction=transactions[1],
-        date=datetime.date(2022, 8, 2),
-        payee="Bob",
-        narration="Home food",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-42.0")),
-        ],
-    )
+      2022-08-02 * "Bob" "Home food"
+        Assets:N26  -42.0 EUR
 
-    assert_transaction(
-        transaction=transactions[2],
-        date=datetime.date(2022, 8, 3),
-        payee="Charlie",
-        narration="Foreign food",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("0.574997419221637245793331269")),
-            (
-                "Expenses:Exchange",
-                "EUR",
-                Decimal("-0.574997419221637245793331269"),
-            ),
-            (
-                "Assets:N26",
-                "EUR",
-                Decimal("-9.13") / Decimal("0.9687"),
-                ("CHF", Decimal("0.9687")),
-            ),
-        ],
-    )
+      2022-08-03 * "Charlie" "Foreign food"
+        Assets:N26          0.574997419221637245793331269 EUR
+        Expenses:Exchange  -0.574997419221637245793331269 EUR
+        Assets:N26         -9.425002580778362754206668731 EUR {0.9687 CHF}
 
-    assert_transaction(
-        transaction=transactions[3],
-        date=datetime.date(2022, 8, 4),
-        payee="Mustermann GmbH",
-        narration="MasterCard Payment",
-        postings=[
-            (
-                "Assets:N26",
-                "EUR",
-                Decimal("-12.21") / Decimal("1"),
-                ("EUR", Decimal("1")),
-            ),
-        ],
-    )
-
+      2022-08-04 * "Mustermann GmbH" "MasterCard Payment"
+        Assets:N26  -12.21 EUR {1.0 EUR}
+   """, transactions, allow_incomplete=True)
 
 def test_extract_updated_header(importer, filename):
-    with open(filename, "wb") as fd:
-        fd.write(
-            _format(
-                """
-                "Booking Date","Value Date","Partner Name","Partner Iban",Type,"Payment Reference","Account Name","Amount (EUR)","Original Amount","Original Currency","Exchange Rate"
-                2019-10-10,2019-10-10,Muster GmbH,{iban_number},Presentment,Muster payment,"Main Account",-12.34,,,
-                """,  # NOQA
-                language=importer.language,
-            )
-        )
+    """\
+    "Booking Date","Value Date","Partner Name","Partner Iban",Type,"Payment Reference","Account Name","Amount (EUR)","Original Amount","Original Currency","Exchange Rate"
+    2019-10-10,2019-10-10,Muster GmbH,DE99999999999999999999,Presentment,Muster payment,"Main Account",-12.34,,,
+    """
 
     transactions = importer.extract(filename)
     date = importer.date(filename)
 
     assert date == datetime.date(2019, 10, 10)
 
-    assert len(transactions) == 1
-    assert_transaction(
-        transaction=transactions[0],
-        date=datetime.date(2019, 10, 10),
-        payee="Muster GmbH",
-        narration="Muster payment",
-        postings=[
-            ("Assets:N26", "EUR", Decimal("-12.34")),
-        ],
-    )
+    assert_equal_entries(r"""
+      2019-10-10 * "Muster GmbH" "Muster payment"
+        Assets:N26  -12.34 EUR
+    """, transactions)


### PR DESCRIPTION
- rework test suite to be in line with the ones from `beancount` (see e.g. https://github.com/beancount/beangulp/blob/master/beangulp/importers/csv_test.py)
- fix #67 
- deprecate exchange_fees_account